### PR TITLE
Allow deeply nested subRows to be sorted

### DIFF
--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -321,7 +321,7 @@ function useInstance(instance) {
       // If there are sub-rows, sort them
       sortedData.forEach(row => {
         sortedFlatRows.push(row)
-        if (!row.subRows || row.subRows.length <= 1) {
+        if (!row.subRows || row.subRows.length === 0) {
           return
         }
         row.subRows = sortData(row.subRows)


### PR DESCRIPTION
Subrows currently do not sort beyond a parent that is of length 1. For example, the given row structure would not sort beyond the first row, even though it has multiple subRows:
```[{
	// sorting terminates here because length of subRows = 1
	subRows: [{
		// these rows are never sorted
		subRows: [{
			// nested sub-sub-row 1
			}, {
			// nested sub-sub-row 2
			}, {
			// nested sub-sub-row 2
			}]
	}]
}]```